### PR TITLE
[Build] Move platforms to the right section

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -33,8 +33,8 @@ jobs:
 
     - name: Build and push
       uses: docker/build-push-action@v5
-      platforms: linux/amd64,linux/arm64
       with:
         context: .
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
In previous PR I've put platforms in the wrong part of the build config. This should fix the issue.