### PR TITLE
[Core] Better error handling

### DIFF
--- a/modules/base/po/cs.popie
+++ b/modules/base/po/cs.popie
@@ -427,6 +427,12 @@ msgstr Výjimka modulu
 msgid Translation error
 msgstr Chyba překladu
 
+msgid Database error!
+msgstr Chyba databáze!
+
+msgid Database has been restored, changes were rolled back.
+msgstr Databáze byla obnovena, změny byly vráceny.
+
 msgid Error
 msgstr Chyba
 

--- a/modules/base/po/sk.popie
+++ b/modules/base/po/sk.popie
@@ -427,6 +427,12 @@ msgstr Výnimka modulu
 msgid Translation error
 msgstr Chyba prekladu
 
+msgid Database error!
+msgstr Chyba databazy!
+
+msgid Database has been restored, changes were rolled back.
+msgstr Databáza bola obnovená, zmeny boli vrátené späť.
+
 msgid Error
 msgstr Chyba
 

--- a/strawberry.py
+++ b/strawberry.py
@@ -189,7 +189,7 @@ async def on_ready():
         already_loaded = True
 
 
-async def handle_error(error: Exception):
+async def handle_error(error: Exception, source: str):
     # Make sure we rollback the database session if we encounter an error
     if isinstance(error, sqlalchemy.exc.SQLAlchemyError):
         database.session.rollback()
@@ -204,10 +204,14 @@ async def handle_error(error: Exception):
         await bot_log.critical(
             None,
             None,
-            "Uncaught error bubbled-up:\n"
-            + str(error)
-            + "\n"
-            + "\n".join(traceback.format_tb(error.__traceback__)),
+            (
+                "Uncaught error bubbled-up.\n"
+                + (f"Source: {source}.\n" if source else "")
+                + "Traceback: \n"
+                + str(error)
+                + "\n"
+                + "\n".join(traceback.format_tb(error.__traceback__))
+            ),
         )
 
 
@@ -221,7 +225,8 @@ commands.Bot.on_error = on_error
 
 
 async def on_itx_error(self, itx: discord.Interaction, error: Exception) -> None:
-    await handle_error(error)
+    source = itx.command.qualified_name if itx.command else None
+    await handle_error(error, source)
 
 
 discord.ui.Modal.on_error = on_itx_error

--- a/strawberry.py
+++ b/strawberry.py
@@ -205,7 +205,8 @@ async def handle_error(error: Exception):
             None,
             None,
             "Uncaught error bubbled-up:\n"
-            + str(error) + "\n"
+            + str(error)
+            + "\n"
             + "\n".join(traceback.format_tb(error.__traceback__)),
         )
 
@@ -225,6 +226,9 @@ async def on_itx_error(self, itx: discord.Interaction, error: Exception) -> None
 
 discord.ui.Modal.on_error = on_itx_error
 discord.ui.View.on_error = on_itx_error
+discord.app_commands.Command.on_error = on_itx_error
+discord.app_commands.Group.on_error = on_itx_error
+discord.app_commands.CommandTree.on_error = on_itx_error
 
 
 from modules.base.admin.database import BaseAdminModule


### PR DESCRIPTION
Currently the error handling was a bit sloppy. The default on_error handlers in Modal and View objects would cause the error to be logged only into std_error and not into bot logs, which might cause trouble as the error won't be noticed unless somebody is actively looking for it.

The second problem was that if there was an command error, the session in SQLAlchemy might not be rolled back. The 2nd commit fixes this issue as well.