### PR TITLE
[Logging] Fix non-available target

### DIFF
--- a/pie/logger/__init__.py
+++ b/pie/logger/__init__.py
@@ -295,6 +295,8 @@ class AbstractLogger:
         for conf in confs:
             try:
                 channel = self.bot.get_guild(conf.guild_id).get_channel(conf.channel_id)
+                for stub in output:
+                    await channel.send(f"```{stub}```")
             except AttributeError as exc:
                 message: str = "Log event target is not available"
 
@@ -309,9 +311,6 @@ class AbstractLogger:
                     f"{message}: {exc!s}.",
                 )
                 continue
-
-            for stub in output:
-                await channel.send(f"```{stub}```")
 
     async def debug(
         self,


### PR DESCRIPTION
Fixes this:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/.local/lib/python3.11/site-packages/discord/ext/commands/core.py", line 235, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/mgmt/verify/module.py", line 106, in verify
    email_sent = await self._send_email(ctx, message)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/mgmt/verify/module.py", line 1467, in _send_email
    await bot_log.warning(
  File "/strawberry-py/pie/logger/__init__.py", line 354, in warning
    await self._log(
  File "/strawberry-py/pie/logger/__init__.py", line 276, in _log
    await self._maybe_send(entry)
  File "/strawberry-py/pie/logger/__init__.py", line 314, in _maybe_send
    await channel.send(f"{stub}")
          ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'send'
```