### PR TITLE
[Errors] Database error logging causes AttributeError

### DIFF
--- a/modules/base/errors/module.py
+++ b/modules/base/errors/module.py
@@ -375,9 +375,7 @@ class Errors(commands.Cog):
 
         return (
             _(utx, "Database error!"),
-            _(utx, "Database has been restored, changes were rolled back.").format(
-                delay=error.retry_after
-            ),
+            _(utx, "Database has been restored, changes were rolled back.").format(),
             ReportTraceback.YES,
         )
 


### PR DESCRIPTION
Fixes:

```
friday-bot | During handling of the above exception, another exception occurred:
friday-bot |
friday-bot | Traceback (most recent call last):
friday-bot |   File "/root/.local/lib/python3.12/site-packages/discord/app_commands/tree.py", line 1089, in wrapper
friday-bot |     await self._call(interaction)
friday-bot |   File "/root/.local/lib/python3.12/site-packages/discord/app_commands/tree.py", line 1218, in _call
friday-bot |     await self._call_context_menu(interaction, data, type)
friday-bot |   File "/root/.local/lib/python3.12/site-packages/discord/app_commands/tree.py", line 1194, in _call_context_menu
friday-bot |     await self.on_error(interaction, e)
friday-bot |   File "/strawberry-py/modules/base/errors/module.py", line 206, in on_tree_error
friday-bot |     title, content, ignore_traceback = await Errors.handle_exceptions(itx, error)
friday-bot |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
friday-bot |   File "/strawberry-py/modules/base/errors/module.py", line 285, in handle_exceptions
friday-bot |     return await Errors.handle_DatabaseException(utx, error)
friday-bot |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
friday-bot |   File "/strawberry-py/modules/base/errors/module.py", line 379, in handle_DatabaseException
friday-bot |     delay=error.retry_after
friday-bot |           ^^^^^^^^^^^^^^^^^
friday-bot | AttributeError: 'PendingRollbackError' object has no attribute 'retry_after'

```