### PR TITLE
Upgrade postgres to 16 + add migration script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,17 @@ version: "3.6"
 
 services:
   db:
-    image: docker.io/postgres:13-alpine
+    image: docker.io/postgres:16-alpine
     container_name: ${INSTANCE_NAME}-db
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - postgres_16_data:/var/lib/postgresql/data/
     environment:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=${DB_USER}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     restart: unless-stopped
   backup:
-    image: docker.io/prodrigestivill/postgres-backup-local:13-alpine
+    image: docker.io/prodrigestivill/postgres-backup-local:16-alpine
     container_name: ${INSTANCE_NAME}-backup
     restart: unless-stopped
     volumes:
@@ -38,4 +38,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  postgres_data:
+  postgres_16_data:

--- a/upgrade-postgres.ps1
+++ b/upgrade-postgres.ps1
@@ -1,0 +1,28 @@
+get-content .env | ForEach-Object {
+    if ($_ -like "*=*") {
+		$name, $value = $_.split('=',[System.StringSplitOptions]::RemoveEmptyEntries)
+		set-content env:$name $value
+	}
+}
+
+docker-compose down
+
+docker compose -f upgrade-postgres.yml up -d
+
+Start-Sleep 15
+
+docker compose -f upgrade-postgres.yml exec -it db_postgres_13 /bin/bash -c "pg_dumpall -U $($ENV:DB_USER) > /backup/backup.sql"
+
+docker compose -f upgrade-postgres.yml exec -it db_postgres_16 /bin/bash -c "psql -d $($ENV:DB_NAME) -U $($ENV:DB_USER) < /backup/backup.sql"
+
+docker compose -f upgrade-postgres.yml exec -it db_postgres_16 /bin/bash -c "echo ALTER USER $($ENV:DB_USER) WITH PASSWORD \'$($ENV:DB_PASSWORD)\' > /backup/reset.txt"
+
+docker compose -f upgrade-postgres.yml exec -it db_postgres_16 /bin/bash -c "psql -U $($ENV:DB_USER) < /backup/reset.txt"
+
+docker compose -f upgrade-postgres.yml exec -it db_postgres_16 /bin/bash -c "rm /backup/reset.txt"
+docker compose -f upgrade-postgres.yml exec -it db_postgres_16 /bin/bash -c "rm /backup/backup.txt"
+
+docker compose -f upgrade-postgres.yml down
+
+Write-Output "DONE!"
+Read-Host

--- a/upgrade-postgres.sh
+++ b/upgrade-postgres.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This script can be used as example of how to migrate the database.
+# As every system is a bit different, nobody can guarantee that this
+# exact script will work. However the general idea of running two
+# postgres docker containers with intra-connected backup folder
+# used to gather the export of version 13 to be imported into
+# version 16 works well.
+
+read -p "Are you sure? (Y/n)" -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  echo "Let's migrate!"
+else
+  exit
+fi
+
+set -a
+. ./.env
+set +a
+
+docker-compose down
+
+docker-compose -f upgrade-postgres.yml up -d
+
+sleep 15s
+
+container_13_id="$( docker ps -a | grep ${INSTANCE_NAME}-dbold | cut -d' ' -f1)"
+container_16_id="$( docker ps -a | grep ${INSTANCE_NAME}-dbupgrade | cut -d' ' -f1)"
+
+docker exec -it $container_13_id /bin/bash -c "pg_dumpall -U ${DB_USER} > /backup/backup.sql"
+
+docker exec -it $container_16_id /bin/bash -c "psql -d ${DB_NAME} -U ${DB_USER} < /backup/backup.sql"
+
+docker exec -it $container_16_id /bin/bash -c "echo ALTER USER ${DB_USER} WITH PASSWORD \'${DB_PASSWORD}\' > /backup/reset.txt"
+
+docker exec -it $container_16_id /bin/bash -c "psql -U ${DB_USER} < /backup/reset.txt"
+
+docker exec -it $container_16_id /bin/bash -c "rm /backup/reset.txt"
+docker exec -it $container_16_id /bin/bash -c "rm /backup/backup.sql"
+
+docker-compose -f upgrade-postgres.yml down
+
+echo "DONE!"

--- a/upgrade-postgres.yml
+++ b/upgrade-postgres.yml
@@ -1,0 +1,30 @@
+version: "3.6"
+
+services:
+  db_postgres_13:
+    container_name: ${INSTANCE_NAME}-dbold
+    image: postgres:13-alpine
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - db_backup:/backup
+    environment:
+      - POSTGRES_DB=${DB_NAME}
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+
+  # we add the new database instance
+  db_postgres_16:
+    container_name: ${INSTANCE_NAME}-dbupgrade
+    image: postgres:16-alpine
+    volumes:
+      - postgres_16_data:/var/lib/postgresql/data
+      - db_backup:/backup
+    environment:
+      - POSTGRES_DB=${DB_NAME}
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+
+volumes:
+    db_backup:
+    postgres_data:
+    postgres_16_data:


### PR DESCRIPTION
As the last release of PostgreSQL 13 is planned on Nov 13 2025, it might be good idea to bump the version to PostgreSQL 16.

This requires not just bumping the version, but also migrating the data as PSQL can't do that automatically when doing major version upgrade.

Because of that, there is a bit of a change in the way we handle PSQL data volumes. From now on, the PSQL volume name must contain the major version. The reason is that in this makes the migration easier as for the migration the data must be dumped somewhere and then imported. Also it acts as a backup - so when something goes south during the migration, the new DB can be wiped and re-imported from the old one.

I've also added PowerShell and Bash script that can be used either to automatically migrate the DB or to go step by step and do the upgrade manually.

I'm not exactly sure how this will work with Kubernetes pods, but that's not fully supported feature.