### PR TITLE
[Error] Fix original error handling

### DIFF
--- a/modules/base/errors/module.py
+++ b/modules/base/errors/module.py
@@ -188,6 +188,8 @@ class Errors(commands.Cog):
             print(itx.command.on_error)
             return
 
+        original_error = None
+
         if getattr(error, "original", None):
             original_error = error.original
         elif getattr(error, "__cause__", None):
@@ -244,6 +246,8 @@ class Errors(commands.Cog):
             original_error = error.original
         elif getattr(error, "__cause__", None):
             original_error = error.__cause__
+
+        original_error = None
 
         if original_error is not None:
             if not isinstance(error, discord.DiscordException):


### PR DESCRIPTION
Fixes: 
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/.local/lib/python3.12/site-packages/discord/ui/view.py", line 432, in _scheduled_task
    return await self.on_error(interaction, e, item)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/base/errors/module.py", line 60, in on_ui_error
    await self.on_tree_error(itx=itx, error=error)
  File "/strawberry-py/modules/base/errors/module.py", line 196, in on_tree_error
    if original_error is not None:
```