### PR TITLE
[Error] Change handling order

### DIFF
--- a/modules/base/errors/module.py
+++ b/modules/base/errors/module.py
@@ -446,14 +446,14 @@ class Errors(commands.Cog):
         if isinstance(error, discord.HTTPException):
             return await Errors.handle_HTTPException(utx, error)
 
+        if isinstance(error, commands.ExtensionError):
+            return await Errors.handle_ExtensionError(utx, error)
+
         if isinstance(error, app_commands.AppCommandError):
             return await Errors.handle_AppCommandError(utx, error)
 
         if isinstance(error, commands.CommandError):
             return await Errors.handle_CommandError(utx, error)
-
-        if isinstance(error, commands.ExtensionError):
-            return await Errors.handle_ExtensionError(utx, error)
 
         return (
             _(utx, "Error"),


### PR DESCRIPTION
```ERROR arcascz (140547421733126145) #castigliano-commands VUT FSI: CommandInvokeError: Command raised an exception: ExtensionAlreadyLoaded: Extension 'modules.fun.macro.module' is already loaded.
Traceback (most recent call last):
  File "/root/.local/lib/python3.12/site-packages/discord/ext/commands/core.py", line 235, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/base/admin/module.py", line 395, in module_load
    await self.bot.load_extension("modules." + name + ".module")
  File "/strawberry-py/pie/bot.py", line 142, in load_extension
    raise commands.ExtensionAlreadyLoaded(name)
discord.ext.commands.errors.ExtensionAlreadyLoaded: Extension 'modules.fun.macro.module' is already loaded.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/.local/lib/python3.12/site-packages/discord/ext/commands/bot.py", line 1366, in invoke
    await ctx.command.invoke(ctx)
  File "/root/.local/lib/python3.12/site-packages/discord/ext/commands/core.py", line 1650, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/root/.local/lib/python3.12/site-packages/discord/ext/commands/core.py", line 1029, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.12/site-packages/discord/ext/commands/core.py", line 244, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: ExtensionAlreadyLoaded: Extension 'modules.fun.macro.module' is already loaded.
```