### PR TITLE
[Pie] DB updating using Alembic

### DIFF
--- a/pie/acl/database.py
+++ b/pie/acl/database.py
@@ -7,6 +7,8 @@ from sqlalchemy import BigInteger, Boolean, Column, Enum, Integer, String
 
 from pie.database import database, session
 
+VERSION = 1
+
 
 class ACLevel(enum.IntEnum):
     BOT_OWNER: int = 5

--- a/pie/database/__init__.py
+++ b/pie/database/__init__.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import importlib
 import os
 from typing import List
 
-from sqlalchemy import create_engine
+from sqlalchemy import Column, Engine, Integer, String, create_engine, inspect
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 from pie.cli import COLOR
@@ -13,7 +15,7 @@ class Database:
 
     def __init__(self):
         self.base = declarative_base()
-        self.db = create_engine(
+        self.db: Engine = create_engine(
             os.getenv("DB_STRING"),
             # This forces the SQLAlchemy 1.4 to use the 2.0 syntax
             future=True,
@@ -24,31 +26,65 @@ database = Database()
 session: Session = sessionmaker(database.db, future=True)()
 
 
+class DatabaseVersion(database.base):
+    """Table that holds and manages DB versioning info for modules.
+
+    :param module_name: Name of the module (with dots as path separators).
+    :param version: Version of the module DB.
+    """
+
+    __tablename__ = "database_versions"
+    module_name = Column(String, primary_key=True)
+    version = Column(Integer)
+
+    def get(module_name: str) -> DatabaseVersion:
+        """Returns the current version for DB stub.
+
+        :module_name: Name of the module (with dots as path separators)
+        """
+        db_version = (
+            session.query(DatabaseVersion)
+            .filter_by(module_name=module_name)
+            .one_or_none()
+        )
+        return db_version
+
+    def set(module_name: str, version: int) -> DatabaseVersion:
+        """Sets the current version for DB stub.
+
+        :module_name: Name of the module (with dots as path separators)
+        :db_version: Version of the DB to set
+        """
+        db_version = (
+            session.query(DatabaseVersion)
+            .filter_by(module_name=module_name)
+            .one_or_none()
+        )
+        if not db_version:
+            db_version = DatabaseVersion(module_name=module_name, version=1)
+
+        db_version.version = version
+
+        session.merge(db_version)
+        session.commit()
+
+        return db_version
+
+
 def init_core():
     """Load core models and create their tables.
 
     This function is responsible for creation of all core tables.
     """
-    # Everything depends on config, we have to initiate it first
-    importlib.import_module("pie.database.config")
-    database.base.metadata.create_all(database.db)
-
-    for module in ("acl", "i18n", "logger", "storage", "spamchannel"):
-        import_stub: str = f"pie.{module}.database"
-        try:
-            importlib.import_module(import_stub)
-            print(
-                f"Database models {COLOR.green}{import_stub}{COLOR.none} imported."
-            )  # noqa: T001
-        except Exception as exc:
-            print(
-                f"Database models {COLOR.red}{import_stub}{COLOR.none} failed: "
-                f"{COLOR.cursive}{exc}{COLOR.none}."
-            )  # noqa: T001
-            raise
-
+    # Everything depends on DB versioning, we have to make sure it's created
     database.base.metadata.create_all(database.db)
     session.commit()
+
+    _import_database(module_name="pie.database.config")
+
+    for module in ("acl", "i18n", "logger", "storage", "spamchannel"):
+        module_name: str = f"pie.{module}.database"
+        _import_database(module_name=module_name)
 
 
 def init_modules():
@@ -56,10 +92,99 @@ def init_modules():
 
     This function is responsible for creation of all module tables.
     """
-    _import_database_tables()
+    repositories: List[str] = _list_directory_directories("modules")
+    for repository in repositories:
+        modules: List[str] = _list_directory_directories(repository)
+        for module in modules:
+            # Detect module's database files
+            database_stub: str = os.path.join(module, "database")
+            if not os.path.isfile(database_stub + ".py") and not os.path.isdir(
+                database_stub
+            ):
+                continue
 
-    database.base.metadata.create_all(database.db)
-    session.commit()
+            module_name = database_stub.replace(os.sep, ".")
+
+            # Import the module DB
+            _import_database(module_name=module_name)
+
+
+def _get_module_tables(module_name: str):
+    return [
+        class_reg_value.__tablename__
+        for class_reg_value in database.base.registry._class_registry.values()
+        if getattr(class_reg_value, "__module__") == module_name
+        and hasattr(class_reg_value, "__tablename__")
+    ]
+
+
+def _import_database(module_name: str):
+    """This functions imports the DB file (if exists).
+
+    It also checks the DB file version against the DBVersion table.
+
+    If the DB scheme is outdated, performs an update.
+
+    Default version is 1 (to stay compatible with)
+
+    :module_name: Name of the module (with dots as path separators)
+    """
+    try:
+        db_module = importlib.import_module(module_name)
+
+        module_version: int = getattr(db_module, "VERSION", 1)
+        db_version: DatabaseVersion = DatabaseVersion.get(module_name=module_name)
+
+        # Check if the DB is created from scratch. If so, set the DBVersion to current Module version.
+        inspector = inspect(database.db)
+        module_tables = _get_module_tables(module_name)
+        existing_tables = inspector.get_table_names()
+        found = False
+        for table in module_tables:
+            if table in existing_tables:
+                found = True
+                break
+        if not found:
+            db_version = DatabaseVersion.set(
+                module_name=module_name, version=module_version
+            )
+
+        current_version = db_version.version if db_version else 1
+
+        database.base.metadata.create_all(database.db)
+        session.commit()
+
+        for version in range(current_version, module_version):
+            print(
+                f"Updating database models {COLOR.green}{module_name}{COLOR.none}"
+                + f" from version {COLOR.green}{version}{COLOR.none}"
+                + f" to {COLOR.green}{version + 1}{COLOR.none}."
+            )
+            _update_schemes(module_name, version)
+
+        print(
+            f"Database models {COLOR.green}{module_name}{COLOR.none}"
+            + f" version {COLOR.green}{module_version}{COLOR.none} imported."
+        )
+    except Exception as exc:
+        session.rollback()
+        print(
+            f"Database models {COLOR.red}{module_name}{COLOR.none} failed: "
+            f"{COLOR.cursive}{exc}{COLOR.none}."
+        )  # noqa: T001
+        raise
+
+
+def _update_schemes(module_name: str, version: int):
+    """Update the schemes for the DB."""
+    path = module_name.split(".")
+    path[-1] = "updates"
+    path.append(f"update_{version}_to_{version + 1}")
+
+    update_stub = ".".join(path)
+    update = importlib.import_module(update_stub)
+    update.run()
+    DatabaseVersion.set(module_name=module_name, version=version + 1)
 
 
 def _list_directory_directories(directory: str) -> List[str]:
@@ -81,38 +206,3 @@ def _list_directory_directories(directory: str) -> List[str]:
     filenames = [f for f in all_files if not f.startswith("_")]
     files = [os.path.join(directory, d) for d in filenames]
     return [d for d in files if os.path.isdir(d)]
-
-
-def _import_database_tables():
-    """Import database tables from the ``modules/`` directory.
-
-    When the tables are imported, :meth:`init_modules` can create their tables.
-    """
-    repositories: List[str] = _list_directory_directories("modules")
-    for repository in repositories:
-        modules: List[str] = _list_directory_directories(repository)
-        for module in modules:
-            # Detect module's database files
-            # TODO This has not been tested with "database/" as directory.
-            # 1/ Do we need that functionality?
-            # 2/ Do we want to support this? It may be solved just by importing the modules
-            #    to the "database/__init__.py" file.
-            database_stub: str = os.path.join(module, "database")
-            if not os.path.isfile(database_stub + ".py") and not os.path.isdir(
-                database_stub
-            ):
-                continue
-
-            # Import the module
-            try:
-                import_stub: str = database_stub.replace("/", ".")
-                importlib.import_module(import_stub)
-                print(
-                    f"Database models {COLOR.green}{import_stub}{COLOR.none} imported."
-                )  # noqa: T001
-            except ModuleNotFoundError as exc:
-                # TODO How to properly log errors?
-                print(
-                    f"Database models {COLOR.red}{import_stub}{COLOR.none} failed: "
-                    f"{COLOR.cursive}{exc}{COLOR.none}."
-                )  # noqa: T001

--- a/pie/database/__init__.py
+++ b/pie/database/__init__.py
@@ -61,16 +61,7 @@ class DatabaseVersion(database.base):
         :module_name: Name of the module (with dots as path separators)
         :db_version: Version of the DB to set
         """
-        db_version = (
-            session.query(DatabaseVersion)
-            .filter_by(module_name=module_name)
-            .one_or_none()
-        )
-        if not db_version:
-            db_version = DatabaseVersion(module_name=module_name, version=1)
-
-        db_version.version = version
-
+        db_version = DatabaseVersion(module_name=module_name, version=version)
         session.merge(db_version)
         session.commit()
 

--- a/pie/database/__init__.py
+++ b/pie/database/__init__.py
@@ -4,8 +4,14 @@ import importlib
 import os
 from typing import List
 
-from sqlalchemy import Column, Engine, Integer, String, create_engine, inspect
-from sqlalchemy.orm import Session, declarative_base, sessionmaker
+from sqlalchemy import Engine, String, create_engine, inspect
+from sqlalchemy.orm import (
+    Mapped,
+    Session,
+    declarative_base,
+    mapped_column,
+    sessionmaker,
+)
 
 from pie.cli import COLOR
 
@@ -34,8 +40,8 @@ class DatabaseVersion(database.base):
     """
 
     __tablename__ = "database_versions"
-    module_name = Column(String, primary_key=True)
-    version = Column(Integer)
+    module_name: Mapped[str] = mapped_column(String, primary_key=True)
+    version: Mapped[int]
 
     def get(module_name: str) -> DatabaseVersion:
         """Returns the current version for DB stub.

--- a/pie/database/config.py
+++ b/pie/database/config.py
@@ -6,6 +6,8 @@ from sqlalchemy import Column, Integer, String
 
 from pie.database import database, session
 
+VERSION = 1
+
 
 class Config(database.base):
     """Global bot configuration."""

--- a/pie/database/updates/EXAMPLE-update_1_to_2.py
+++ b/pie/database/updates/EXAMPLE-update_1_to_2.py
@@ -1,0 +1,56 @@
+"""This is an example on how to handle DB updates from version to version
+
+The name of the file must be update_{version}_to_{version+1}.py
+For example: `update_1_to_2.py`
+The file must be placed into folder `updates` located in the same directory
+as database.py file for the module
+For example:
+    `./pie/acl/updates/update_1_to_2.py`
+    `./modules/base/errors/updates/update_1_to_2.py`
+
+The update can be done only from version to version + 1 (can't skip versions).
+
+The inspector should be used to figure out if the update is needed.
+It might happen that the module with newer schema is freshly installed
+before the core is updated to the version that supports DB updates
+"""
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import Column, Integer, inspect
+
+from pie.database import database
+
+
+def run():
+    # We are using inspector to make sure the changes are necessary
+    inspector = inspect(database.db)
+
+    # Connect to database and create migration context
+    with database.db.connect() as conn:
+        mc = MigrationContext.configure(conn)
+
+        # We are using transaction so either all changes passes or none passes
+        with mc.begin_transaction():
+            ops = Operations(mc)
+
+            # Check that the rename of the table is needed
+            if "old_boring_name" in inspector.get_table_names():
+                ops.rename_table("old_boring_name", "cool_new_name")
+
+            # Get column names for table `my_table`
+            my_table_columns = [
+                column["name"] for column in inspector.get_columns("my_table")
+            ]
+
+            # Check if the column needs to be renamed. This can be also used to add / remove column
+            if "my_old_name" in my_table_columns:
+                ops.alter_column(
+                    "my_table", column_name="my_old_name", new_column_name="my_new_name"
+                )
+
+            # Adds a column and sets the value for all rows
+            if "add_this" not in my_table_columns:
+                column = Column(Integer, name="add_this", default=42)
+                ops.add_column(table_name="my_table", column=column)
+                ops.execute("UPDATE my_table SET add_this = 42")

--- a/pie/i18n/database.py
+++ b/pie/i18n/database.py
@@ -6,6 +6,8 @@ from sqlalchemy import BigInteger, Column, Integer, String
 
 from pie.database import database, session
 
+VERSION = 1
+
 
 class GuildLanguage(database.base):
     """Language preference for the guild.

--- a/pie/logger/database.py
+++ b/pie/logger/database.py
@@ -6,6 +6,8 @@ from sqlalchemy import BigInteger, Column, Integer, String
 
 from pie.database import database, session
 
+VERSION = 1
+
 
 class LogConf(database.base):
     """Log configuration.

--- a/pie/spamchannel/database.py
+++ b/pie/spamchannel/database.py
@@ -6,6 +6,8 @@ from sqlalchemy import BigInteger, Boolean, Column, Integer, UniqueConstraint
 
 from pie.database import database, session
 
+VERSION = 1
+
 
 class SpamChannel(database.base):
     __tablename__ = "spamchannels"

--- a/pie/storage/database.py
+++ b/pie/storage/database.py
@@ -6,6 +6,8 @@ from sqlalchemy import BigInteger, Column, String
 
 from pie.database import database, session
 
+VERSION = 1
+
 
 class StorageData(database.base):
     __tablename__ = "pie_storage_data"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests>=2.27.1,<3.0.0
 SQLAlchemy>=2.0.0,<2.1.0
 ring>=0.9.1,<1.0.0
 python-dateutil>=2.8.2,<3.0.0
+alembic>=1.13.3,<2.0.0


### PR DESCRIPTION
Currnetly the issue is that if the DB scheme is changed, it's necessary to perform a manual update of the database scheme, which might be complicated and also is inconvinient for the end user.

Because of that I've added a feature that allows developers to specify a version of the DB scheme and perform changes of the DB using Alembic.

The automatic generating of migration scripts is not supported (yet) as I don't exactly know how to set it up so it will generate the script only for the base and it's modules and not for all currently installed modules in dev / test environment.

However, I've added a example of how to create the update file. The file must be placed into folder `updates` located in the same directory as database.py file for the module.

After the merge, I will update the docs.