### PR TITLE
[Errors] Better handling of TransformerError

### DIFF
--- a/modules/base/errors/module.py
+++ b/modules/base/errors/module.py
@@ -640,9 +640,23 @@ class Errors(commands.Cog):
 
         if isinstance(error, app_commands.TransformerError):
             return (
-                _(utx, "Command transformer error"),
-                _(utx, "Command transformer error"),
-                ReportTraceback.YES,
+                _(utx, "AppCommand transformer error"),
+                _(
+                    utx,
+                    "Transformer `{transformer}` failed to transform value `{value}` into type `{type}`.",
+                ).format(
+                    transformer=type(error.transformer).__name__,
+                    value=error.value,
+                    type=error.type.name,
+                )
+                + (
+                    _(utx, "Cause: {cause}").format(
+                        cause=type(error.__cause__).__name__
+                    )
+                    if getattr(error, "__cause__ ", None)
+                    else ""
+                ),
+                ReportTraceback.NO,
             )
 
         if isinstance(error, app_commands.CommandLimitReached):

--- a/modules/base/po/cs.popie
+++ b/modules/base/po/cs.popie
@@ -526,8 +526,14 @@ msgstr Chyba ve volání příkazu
 msgid Command translation error
 msgstr Chyba v překladu příkazu
 
-msgid Command transformer error
-msgstr Chyba transformátoru příkazu
+msgid AppCommand transformer error
+msgstr Chyba AppCommand transformátoru
+
+msgid Transformer `{transformer}` failed to transform value `{value}` into type `{type}`.
+msgstr Transformátoru `{transformer}` se nepodařilo transformovat hodnotu `{value}` na typ `{type}`.
+
+msgid Cause: {cause}
+msgstr Důvod: {cause}
 
 msgid Command limit reached
 msgstr Dosažen limit příkazů
@@ -536,7 +542,7 @@ msgid Discord command limit for bot reached
 msgstr Dosažen limit příkazů bota stanovený Discordem
 
 msgid Command already registered
-msgstr Příakz je již registrován
+msgstr Příkaz je již registrován
 
 msgid Command {name} is already registered. Guild ID: {guild_id}.
 msgstr Příkaz {name} je již registrován. ID Guildy: {guild_id}.

--- a/modules/base/po/sk.popie
+++ b/modules/base/po/sk.popie
@@ -526,8 +526,14 @@ msgstr Chyba pri volaní príkazu
 msgid Command translation error
 msgstr Chyba prekladu príkazu
 
-msgid Command transformer error
-msgstr Chyba príkazového transformátora
+msgid AppCommand transformer error
+msgstr Chyba AppCommand transformátora
+
+msgid Transformer `{transformer}` failed to transform value `{value}` into type `{type}`.
+msgstr Transformátoru `{transformer}` sa nepodarilo transformovať hodnotu `{value}` na typ `{type}`.
+
+msgid Cause: {cause}
+msgstr Dôvod: {cause}
 
 msgid Command limit reached
 msgstr Bol dosiahnutý limit príkazov


### PR DESCRIPTION
It might be a good idea to handle the transformer errors more gracefuly than just throwing an error into log.

The errors might happen when for example the deleted user is converted to Member (example: https://github.com/strawberry-py/strawberry-management/pull/37).

It also fixes a typo in one of the translaitons.