### PR TITLE
[Profiler] Add manual profiler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ modules/*
 
 # Backups
 backups/*
+
+# Profiler
+.profiler
+profiler_results.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ring>=0.9.1,<1.0.0
 python-dateutil>=2.8.2,<3.0.0
 alembic>=1.13.3,<2.0.0
 audioop-lts; python_version>='3.13'
+pyinstrument

--- a/strawberry.py
+++ b/strawberry.py
@@ -8,6 +8,8 @@ import traceback
 from pathlib import Path
 from typing import Dict
 
+import pyinstrument
+
 import discord
 
 from pie import exceptions
@@ -15,6 +17,13 @@ from pie.bot import Strawberry
 from pie.cli import COLOR
 
 # Setup checks
+
+profiler_path = ".profiler"
+profiler = None
+if os.path.exists(profiler_path):
+    profiler = pyinstrument.Profiler()
+    profiler.start()
+    print("Profiler started!")
 
 
 def test_dotenv() -> None:
@@ -115,6 +124,11 @@ except asyncio.exceptions.CancelledError:
 except Exception as e:
     print(traceback.format_exc(e))
     result = 2
+
+if profiler:
+    os.remove(profiler_path)
+    profiler.stop()
+    profiler.write_html("profiler_results.html")
 
 print(f"Exit code: {result}")
 if result:


### PR DESCRIPTION
We are a bit on the blind side regarding the performance and the bottlenecks in Strawberry-py. This change allows user to run profiler by creating .profiler file in the root folder. When the bot is restarted and the file is found, the bot will automatically start profiler. After the bot reboot / shutdown, the .profiler file is removed and the profiler_results.html is generated.

Later on I'd like to add commands to create the .profiler file and to download the results.