### PR TITLE
[Docker] Fix missing ssh command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONUNBUFFERED 1
 # Ignore hadolint check for version specific apt-get install
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get -y --no-install-recommends install \
-    tzdata git \
+    tzdata openssh-client git \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
     && git config --global --add safe.directory '*'
 


### PR DESCRIPTION
The error bellow is thrown when the module is cloned using git and not HTTPS.

Installing OpenSSH client should fix this issue.
```
strawberry-bot     | future: <Task finished name='discord-ext-tasks: Admin.check_updates' coro=<Loop._loop() done, defined at /root/.local/lib/python3.12/site-packages/discord/ext/tasks/__init__.py:202> exception=GitCommandError(['git', 'fetch', '-v', '--', 'origin'], 128, b'error: cannot run ssh: No such file or directory\nfatal: unable to fork')>
strawberry-bot     | Traceback (most recent call last):
strawberry-bot     |   File "/root/.local/lib/python3.12/site-packages/discord/ext/tasks/__init__.py", line 266, in _loop
strawberry-bot     |     raise exc
strawberry-bot     |   File "/root/.local/lib/python3.12/site-packages/discord/ext/tasks/__init__.py", line 241, in _loop
strawberry-bot     |     await self.coro(*args, **kwargs)
strawberry-bot     |   File "/strawberry-py/modules/base/admin/module.py", line 55, in check_updates
strawberry-bot     |     ahead, behind = await status
strawberry-bot     |                     ^^^^^^^^^^^^
strawberry-bot     |   File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run
strawberry-bot     |     result = self.fn(*self.args, **self.kwargs)
strawberry-bot     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
strawberry-bot     |   File "/strawberry-py/pie/repository/__init__.py", line 269, in git_status
strawberry-bot     |     repo.remotes.origin.fetch()
strawberry-bot     |   File "/root/.local/lib/python3.12/site-packages/git/remote.py", line 1076, in fetch
strawberry-bot     |     res = self._get_fetch_info_from_stderr(proc, progress, kill_after_timeout=kill_after_timeout)
strawberry-bot     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
strawberry-bot     |   File "/root/.local/lib/python3.12/site-packages/git/remote.py", line 902, in _get_fetch_info_from_stderr
strawberry-bot     |     proc.wait(stderr=stderr_text)
strawberry-bot     |   File "/root/.local/lib/python3.12/site-packages/git/cmd.py", line 834, in wait
strawberry-bot     |     raise GitCommandError(remove_password_if_present(self.args), status, errstr)
strawberry-bot     | git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
strawberry-bot     |   cmdline: git fetch -v -- origin
strawberry-bot     |   stderr: 'error: cannot run ssh: No such file or directory
```