### PR TITLE
[Pie] Fix repository hash generator

### DIFF
--- a/pie/acl/__init__.py
+++ b/pie/acl/__init__.py
@@ -131,7 +131,7 @@ def acl2(level: ACLevel) -> Callable[[T], T]:
     def decorator(
         func: Union[
             app_commands.commands.Check, commands.Command[Any, ..., Any], CoroFunc
-        ]
+        ],
     ):
         """A combination of app_commands.check() and commands.check()to make things compatible."""
         if isinstance(

--- a/pie/repository/__init__.py
+++ b/pie/repository/__init__.py
@@ -310,10 +310,11 @@ class Repository:
 
         h = hashlib.sha256()
         with open(file, "rb") as handle:
-            chunk: bytes = b""
-            while chunk != b"":
+            while True:
                 # read 1kB at a time
-                chunk = handle.read(1024)
+                chunk = handle.read(65536)
+                if not chunk:
+                    break
                 h.update(chunk)
         file_hash = h.hexdigest()
         return file_hash


### PR DESCRIPTION
For some reason, the old way of hashing the requirements.txt file was generating the same hash for two different files.

~~We need to address this issue.~~

The problem was that the while loop never run, so the hash was always the same.