### PR TITLE
improved split

### DIFF
--- a/pie/utils/text.py
+++ b/pie/utils/text.py
@@ -12,6 +12,7 @@ def sanitise(
         string: A text string to sanitise.
         limit: How many characters should be processed.
         escape: Whether to escape characters (to prevent unwanted markdown).
+        tag_escape: Whether to escape tags (to prevent unwanted tags).
 
     Returns:
         Sanitised string.
@@ -25,17 +26,89 @@ def sanitise(
         return string[:limit]
 
 
-def split(string: str, limit: int = 1990) -> List[str]:
+def split(string: str, limit: int = 1990, min_length: int = 1000) -> List[str]:
     """Split text into multiple smaller ones.
 
     :param string: A text string to split.
     :param limit: How long the output strings should be.
+    :param min_length: Minimal length of the output strings.
     :return: A string split into a list of smaller lines with maximal length of
         ``limit``.
     """
-    return list(string[0 + i : limit + i] for i in range(0, len(string), limit))
+
+    parts = [string]
+
+    # sanitize limits
+    min_length = min(abs(min_length), 1900, limit)
+    limit = min(1990, abs(limit))
+    # split message to chunks of roughly limit chars
+    while len(parts[len(parts) - 1]) > limit:
+        # determine where to split the message
+        split_pos = parts[len(parts) - 1].find(" ", limit)
+        if split_pos > limit or split_pos <= 0:
+            split_pos = parts[len(parts) - 1].rfind(" ", min_length, limit)
+        if split_pos > limit or split_pos <= 0:
+            split_pos = limit
+
+        split_pos_old = split_pos
+
+        part = parts[len(parts) - 1][:split_pos]
+
+        markdown_sanitization_success = False
+
+        # check if markdown marks aren't spilt in half
+        markdown_marks = ["~~", "***", "**", "*", "__", "_", "```", "`"]
+        while not markdown_sanitization_success:
+            markdown_sanitization_success = True
+            for mark in markdown_marks:
+                if part.count(mark) % 2 != 0:
+                    split_pos = part.rfind(mark)
+                    part = part[:split_pos]
+                    markdown_sanitization_success = False
+
+        # if by trying to keep markdown marks complete part to split became to short, add ends of markdown marks to the end
+        marks_to_add_to_start = ""
+        if split_pos < min_length or split_pos <= 0:
+            split_pos = split_pos_old
+            for mark in markdown_marks:
+                if part.count(mark) % 2 == 0:
+                    pass
+                else:
+                    part += mark
+                    marks_to_add_to_start += mark
+
+        # if by adding ends of markdown marks part became too long split it again
+        if len(part) > 2000:
+            parts = split(
+                part, limit - 20
+            )  # make space for potentially adding ends of markdown marks, if it's second pass
+            part = parts[0]
+            split_pos = len(part)
+
+        # check if text is supposed to be bigger, smaller or citation
+        marks = ["### ", "## ", "-# ", "# ", ">>> ", "> "]
+        for mark in marks:
+            tmp = part.split("\n")[-1]
+            if tmp.startswith(mark):
+                if tmp.startswith(
+                    mark + ">>> "
+                ):  # bigger or smaller text can also be citation
+                    mark += ">>> "
+                marks_to_add_to_start = mark + marks_to_add_to_start
+
+        parts.append(
+            "***Continuation***\n"
+            + marks_to_add_to_start
+            + parts[len(parts) - 1][split_pos:].removeprefix(" ")
+        )  # mark remaining text as continuation
+        parts[(len(parts) - 2)] = (
+            part  # update previous part to be roughly limit chars long
+        )
+
+    return parts
 
 
+# consider renaming to merge_lines, makes more sense, since it's merging blocks
 def split_lines(lines: List[str], limit: int = 1990) -> List[str]:
     """Split list of lines to bigger blocks.
 


### PR DESCRIPTION
Improved split by trying to split it in space char

If it would split inside markdown or a code block try to prevent it by splitting before it. If impossible add the end of the block to the end of the part and start the block again in the next part.

Originated from https://github.com/strawberry-py/strawberry-wormhole/pull/41